### PR TITLE
Bugfix: Ensure `--root` directory parameter is enclosed in double quotes

### DIFF
--- a/src/showman/executer.py
+++ b/src/showman/executer.py
@@ -248,7 +248,7 @@ class CodeRunner:
             f' "{selector}"'
             f" --field value"
             f" --format json"
-            f" --root {workspace_dir}"
+            f' --root "{workspace_dir}"'
         )
         self.logger.debug(f"Running command: {cmd}")
         workspace_dir = os.getcwd()


### PR DESCRIPTION
To prevent errors due to white spaces in the directory.